### PR TITLE
fix(workflow): remove unused GITHUB_SECRET from deploy config

### DIFF
--- a/.github/workflows/deploy-vapor.yaml
+++ b/.github/workflows/deploy-vapor.yaml
@@ -49,4 +49,3 @@ jobs:
           command: vapor deploy ${{ github.ref_name }} --commit="${{ github.event.head_commit.id }}" --message="${{ github.event.head_commit.message }}" --without-waiting
         env:
           VAPOR_API_TOKEN: ${{ secrets.VAPOR }}
-          GITHUB_SECRET: ${{ secrets.GITHUB }}


### PR DESCRIPTION
Removes the GITHUB_SECRET environment variable from the deploy 
workflow configuration as it is not needed for the vapor deploy 
command. This simplifies the configuration and reduces potential 
security risks by limiting the number of secrets in use.